### PR TITLE
feat(css-management): setting up tailwindcss in the project for easier css management

### DIFF
--- a/atomic_ui/.editorconfig
+++ b/atomic_ui/.editorconfig
@@ -1,0 +1,14 @@
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/atomic_ui/.eslintrc.json
+++ b/atomic_ui/.eslintrc.json
@@ -1,0 +1,46 @@
+{
+  "ignorePatterns": ["node_modules", "stencil-generated", "dist"],
+  "env": {
+    "jest": true,
+    "es6": true
+  },
+  "extends": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint"],
+      "extends": ["./node_modules/gts"],
+      "parserOptions": {
+        "jsxPragma": "h"
+      },
+      "rules": {
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          { "ignoreRestSiblings": true }
+        ],
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/no-empty-interface": [
+          "error",
+          { "allowSingleExtends": true }
+        ]
+      }
+    },
+    {
+      "files": ["**/*.js", "**/*.jsx"],
+      "extends": ["eslint:recommended"],
+      "rules": {
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+      },
+      "env": {
+        "node": true
+      }
+    }
+  ],
+  "root": true
+}

--- a/atomic_ui/.prettierrc.js
+++ b/atomic_ui/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    bracketSpacing: false,
+    singleQuote: true,
+    trailingComma: 'es5',
+    endOfLine: "auto"
+};

--- a/atomic_ui/package.json
+++ b/atomic_ui/package.json
@@ -15,6 +15,7 @@
     "@coveo/atomic": "^1.36.3",
     "@coveo/headless": "^1.54.0",
     "@coveo/search-token-lambda": "1.25.4",
+    "@stencil/postcss": "^2.1.0",
     "highlight.js": "^11.5.0"
   },
   "devDependencies": {

--- a/atomic_ui/package.json
+++ b/atomic_ui/package.json
@@ -19,10 +19,13 @@
   },
   "devDependencies": {
     "@stencil/core": "2.13.0",
+    "autoprefixer": "^10.4.4",
     "gts": "3.1.0",
     "netlify-cli": "9.3.0",
+    "postcss": "^8.4.12",
     "prettier": "2.5.1",
     "rollup-plugin-dotenv": "0.3.0",
-    "rollup-plugin-html": "0.2.1"
+    "rollup-plugin-html": "0.2.1",
+    "tailwindcss": "^3.0.23"
   }
 }

--- a/atomic_ui/postcss.config.js
+++ b/atomic_ui/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/atomic_ui/src/components/code-search-preview-modal/code-search-preview-modal.css
+++ b/atomic_ui/src/components/code-search-preview-modal/code-search-preview-modal.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .shadow-lg {
   --tw-shadow: 0px -2px 8px rgba(229, 232, 232, 0.75);
 }
@@ -13,6 +17,7 @@
   transform: scale(1.1);
   transition: visibility 0s linear 0.25s, opacity 0.25s 0s, transform 0.25s;
 }
+
 .background {
   position: fixed;
   top: 0;
@@ -26,13 +31,16 @@
 
   overflow: hidden;
 }
+
 .hydrated {
   visibility: unset;
 }
+
 .img {
   width: 26px;
   height: 26px;
 }
+
 .modal-content {
   /*position: absolute;
   top: 1%;
@@ -59,8 +67,8 @@
   background-color: darkgray;
 }
 
-select:hover + div,
-select:focus-visible + div {
+select:hover+div,
+select:focus-visible+div {
   @apply text-primary-light;
 }
 
@@ -72,6 +80,7 @@ select:focus-visible + div {
   /*width: 80%;
     max-width: 32rem;*/
 }
+
 /*
 code-search-preview-modal {
   position: fixed;
@@ -140,9 +149,9 @@ code-search-preview-modal .coveo-modal-content {
   height: calc((50vh));
   overflow: auto;
 }
+
 .animate-scaleUpRefineModal {
-  animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0s 1 normal forwards
-    running scaleUp;
+  animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0s 1 normal forwards running scaleUp;
 }
 
 .animate-slideDownRefineModal {
@@ -154,16 +163,19 @@ code-search-preview-modal .coveo-modal-content {
     transform: scale(0.7) translateY(1000px);
     opacity: 0.7;
   }
+
   100% {
     transform: scale(1) translateY(0px);
     opacity: 1;
   }
 }
+
 @keyframes slideDown {
   0% {
     transform: translateY(0px);
     opacity: 1;
   }
+
   100% {
     transform: translateY(150vh);
     opacity: 0.7;
@@ -177,7 +189,8 @@ code-search-preview-modal {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 100%; /*calc(100vh);*/
+  height: 100%;
+  /*calc(100vh);*/
   z-index: 150;
   background-color: aliceblue;
   display: flex;
@@ -216,6 +229,7 @@ code-search-preview-modal {
   overflow: auto;
   flex-grow: 1;
 }
+
 .centered2 {
   /*margin-left: auto;
     margin-right: auto;*/
@@ -236,10 +250,12 @@ code-search-preview-modal {
     height: 85% !important;*/
   /*top: 20px;*/
 }
+
 .highlight {
   background-color: #53f1df;
   font-size: 12pt;
 }
+
 .header {
   border-bottom: 2px solid rgb(229, 232, 232);
 }
@@ -281,8 +297,7 @@ code-search-preview-modal {
 }
 
 .animate-scaleUpRefineModal {
-  animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0s 1 normal forwards
-    running scaleUp;
+  animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0s 1 normal forwards running scaleUp;
 }
 
 .w-screen {
@@ -326,18 +341,23 @@ code-search-preview-modal {
 .btn-text-transparent:hover {
   color: var(--atomic-primary-light);
 }
+
 .ripple-parent {
   overflow: hidden;
 }
+
 .ripple-relative {
   position: relative;
 }
+
 .place-items-center {
   place-items: center;
 }
+
 .grid {
   display: grid;
 }
+
 .btn-text-transparent {
   border-radius: var(--atomic-border-radius);
   background-color: var(--atomic-background);

--- a/atomic_ui/src/components/code-search-preview/code-search-preview.css
+++ b/atomic_ui/src/components/code-search-preview/code-search-preview.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 img {
   height: 25px;
   width: 25px;
@@ -22,6 +26,7 @@ img {
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/atomic_ui/src/components/code-search-preview/code-search-preview.tsx
+++ b/atomic_ui/src/components/code-search-preview/code-search-preview.tsx
@@ -108,8 +108,11 @@ export class CodeSearchPreviewResultComponent {
     }
     return (
       <div>
-        {icon}
-        {loader}
+        <h1 class="text-3xl font-bold underline">Hello world!</h1>
+        <div>
+          {icon}
+          {loader}
+        </div>
       </div>
     );
   }

--- a/atomic_ui/src/components/code-search-preview/code-search-preview.tsx
+++ b/atomic_ui/src/components/code-search-preview/code-search-preview.tsx
@@ -108,11 +108,8 @@ export class CodeSearchPreviewResultComponent {
     }
     return (
       <div>
-        <h1 class="text-3xl font-bold underline">Hello world!</h1>
-        <div>
-          {icon}
-          {loader}
-        </div>
+        {icon}
+        {loader}
       </div>
     );
   }

--- a/atomic_ui/src/components/code-search/code-search-component.css
+++ b/atomic_ui/src/components/code-search/code-search-component.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 code-search-component {
   font-family: var(--atomic-font-family);
   font-size: small;
@@ -9,12 +13,14 @@ code-search-component {
   margin-top: 5px;
   width: 120px;
 }
+
 @media only screen and (max-width: 1330px) {
   code-search-component {
     float: left;
     margin-left: 15;
   }
 }
+
 @media only screen and (max-width: 1000px) {
   code-search-component {
     float: none;
@@ -45,21 +51,25 @@ code-search-component {
   right: -43px;
   top: 3px;
 }
+
 /* Hide default HTML checkbox */
 .switch input {
   display: none;
 }
+
 .codeSearch input {
   transform: scale(2);
   line-height: 10px;
   height: 10px;
   vertical-align: middle;
 }
+
 .codeSearch label {
   padding-left: 5px;
   line-height: 15px;
   vertical-align: middle;
 }
+
 /* The slider */
 .slider {
   position: absolute;
@@ -85,15 +95,15 @@ code-search-component {
   transition: 0.4s;
 }
 
-input:checked + .slider {
+input:checked+.slider {
   background-color: #2196f3;
 }
 
-input:focus + .slider {
+input:focus+.slider {
   box-shadow: 0 0 1px #2196f3;
 }
 
-input:checked + .slider:before {
+input:checked+.slider:before {
   -webkit-transform: translateX(16px);
   -ms-transform: translateX(16px);
   transform: translateX(16px);

--- a/atomic_ui/src/components/dev-icons-result-component/dev-icons-result-component.css
+++ b/atomic_ui/src/components/dev-icons-result-component/dev-icons-result-component.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 b {
   color: var(--atomic-primary);
 }

--- a/atomic_ui/src/components/find-usage/find-usage-component.css
+++ b/atomic_ui/src/components/find-usage/find-usage-component.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 img {
   height: 25px;
   width: 25px;

--- a/atomic_ui/src/components/recently-opened/recently-opened-component.css
+++ b/atomic_ui/src/components/recently-opened/recently-opened-component.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .small::part(code_image) {
   width: 24px;
   height: 24px;
@@ -9,6 +13,7 @@
   margin-block-start: 0px !important;
   padding-inline-start: 0px !important;
 }
+
 .title {
   font-weight: var(--atomic-font-bold);
   padding-left: 0.5rem;
@@ -47,9 +52,11 @@ div {
   padding: 1rem;
   margin-right: 5px;
 }
+
 .recentList li {
   padding-bottom: 15px;
 }
+
 .recentListItem {
   width: 80%;
   word-break: break-all;

--- a/atomic_ui/stencil.config.ts
+++ b/atomic_ui/stencil.config.ts
@@ -1,27 +1,34 @@
-import {Config} from '@stencil/core';
-import dotenvPlugin from 'rollup-plugin-dotenv';
-import html from 'rollup-plugin-html';
+import { Config } from "@stencil/core";
+import dotenvPlugin from "rollup-plugin-dotenv";
+import html from "rollup-plugin-html";
+import { postcss } from "@stencil/postcss";
+import tailwind from "tailwindcss";
 
 // https://stenciljs.com/docs/config
 
 export const config: Config = {
-  globalStyle: 'src/style/index.css',
-  taskQueue: 'async',
+  globalStyle: "src/style/index.css",
+  taskQueue: "async",
   outputTargets: [
     {
-      type: 'www',
+      type: "www",
       serviceWorker: null, // disable service workers
-      copy: [{src: 'pages', keepDirStructure: false}],
+      copy: [{ src: "pages", keepDirStructure: false }],
     },
   ],
-  plugins: [dotenvPlugin()],
+  plugins: [
+    dotenvPlugin(),
+    postcss({
+      plugins: [tailwind()],
+    }),
+  ],
   rollupPlugins: {
     before: [
       html({
-        include: 'src/components/**/*.html',
+        include: "src/components/**/*.html",
       }),
       html({
-        include: 'src/components/**/*.svg',
+        include: "src/components/**/*.svg",
       }),
     ],
   },

--- a/atomic_ui/tailwind.config.js
+++ b/atomic_ui/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}",],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
### Proposed Changes
Add tailwindcss to try to decrese the frontend styling cxomplexity

### How to test

Add some tailwindcss styling class in a a project's tsx component class (like a [margin ](https://tailwindcss.com/docs/margin) class). 
#### Example

In [code-search-component.tsx](https://github.com/agagnon2/cocos-fork/blob/618e31c8968150a7b100f671cbba7ddc16873cc2/atomic_ui/src/components/code-search/code-search-component.tsx#L274), instead of adding the `first` class that simply adds a margin-bottom of 8 px, we could use the tailwincss class `mb-2` defined as the following :  `margin-bottom: 0.5rem; /* 8px */`, which is equivalent but would remove the need of adding a new css definition.

![image](https://user-images.githubusercontent.com/73175206/167756330-50de76df-e55e-40de-a3bb-b9b48466d1c6.png)

### Scope
Application setup & all react tsx components